### PR TITLE
Fix: 카테고리 트리 조회시 이미지 반환이 안되는 문제 해결

### DIFF
--- a/product-service/src/main/java/com/example/product_service/api/category/service/dto/result/CategoryTreeResponse.java
+++ b/product-service/src/main/java/com/example/product_service/api/category/service/dto/result/CategoryTreeResponse.java
@@ -41,6 +41,7 @@ public class CategoryTreeResponse {
                 .name(category.getName())
                 .parentId((category.getParent() == null) ? null : category.getParent().getId())
                 .depth(category.getDepth())
+                .imageUrl(category.getImageUrl())
                 .build();
     }
 

--- a/product-service/src/test/java/com/example/product_service/api/category/service/CategoryServiceTest.java
+++ b/product-service/src/test/java/com/example/product_service/api/category/service/CategoryServiceTest.java
@@ -124,8 +124,8 @@ public class CategoryServiceTest extends ExcludeInfraTest {
             CategoryResponse result = categoryService.saveCategory("육류", food.getId(), "http://test.jpg");
             //then
             assertThat(result)
-                    .extracting(CategoryResponse::getName, CategoryResponse::getParentId, CategoryResponse::getDepth)
-                    .containsExactly("육류", food.getId(), 2);
+                    .extracting(CategoryResponse::getName, CategoryResponse::getParentId, CategoryResponse::getDepth, CategoryResponse::getImageUrl)
+                    .containsExactly("육류", food.getId(), 2, "http://test.jpg");
 
             Category saved = categoryRepository.findById(result.getId()).orElseThrow();
             assertThat(saved.getPath()).isEqualTo(food.getId() + "/" + saved.getId());
@@ -145,8 +145,8 @@ public class CategoryServiceTest extends ExcludeInfraTest {
             CategoryResponse result = categoryService.getCategory(category.getId());
             //then
             assertThat(result)
-                    .extracting(CategoryResponse::getId, CategoryResponse::getName, CategoryResponse::getParentId, CategoryResponse::getDepth)
-                    .containsExactly(category.getId(), "카테고리", null, 1);
+                    .extracting(CategoryResponse::getId, CategoryResponse::getName, CategoryResponse::getParentId, CategoryResponse::getDepth, CategoryResponse::getImageUrl)
+                    .containsExactly(category.getId(), "카테고리", null, 1, "http://test.jpg");
         }
 
         @Test
@@ -173,10 +173,10 @@ public class CategoryServiceTest extends ExcludeInfraTest {
             //when
             List<CategoryTreeResponse> result = categoryService.getTree();
             //then
-            assertThat(result).extracting(CategoryTreeResponse::getName, CategoryTreeResponse::getDepth)
+            assertThat(result).extracting(CategoryTreeResponse::getName, CategoryTreeResponse::getDepth, CategoryTreeResponse::getImageUrl)
                     .containsExactly(
-                            tuple("전자", 1),
-                            tuple("식품", 1)
+                            tuple("전자", 1, "http://test.jpg"),
+                            tuple("식품", 1, "http://test.jpg")
                     );
 
             CategoryTreeResponse electronics = result.get(0);


### PR DESCRIPTION
Resolves: #376

## 연관 이슈
- Resolves: #376 

---

## 작업 내용
> PR 작업 내용 작성

- 상품 서비스 카테고리 트리조회시 이미지가 반환되지 않는 문제 해결
- 

---

## 변경 유형
- [ ] Feat (기능 추가)
- [x] Fix (버그 수정)
- [ ] Refactor (리팩토링)
- [ ] Docs (문서 수정)
- [ ] Test (테스트 코드)
- [ ] Chore (빌드/설정 변경)

---

## 리뷰

---

## 테스트 결과
- [x] 단위 테스트 완료
- [x] 로컬 테스트 완료